### PR TITLE
Frontend routes Sebastian Davies & Kamila (Januka) 

### DIFF
--- a/backend/src/routes/articles_routes.js
+++ b/backend/src/routes/articles_routes.js
@@ -30,7 +30,7 @@ articleRouter.get("/:id", async (req, res, next) => {
 
 		if (result.rows.length > 0) {
 			const article = result.rows[0];
-			article.tags = article.tags.filter(item => item != null);
+			article.tags = article.tags.filter((item) => item != null);
 
 			res.json(article);
 		} else {
@@ -111,11 +111,7 @@ articleRouter.put("/:id", authenticateToken, async (req, res) => {
 	try {
 		const updateArticle =
 			"UPDATE articles SET title=$1, description=$2 WHERE id = $3";
-		await pool.query(updateArticle, [
-			title,
-			description,
-			id,
-		]);
+		await pool.query(updateArticle, [title, description, id]);
 		// TODO: 404 handling
 
 		// TODO: update tags
@@ -152,7 +148,7 @@ articleRouter.get("/with-tag/:tagName", async (req, res) => {
 });
 
 //Get all tags
-articleRouter.get("/tags", async (req, res) => {
+articleRouter.get("/tags/getall", async (req, res) => {
 	try {
 		const result = await pool.query("SELECT tag_name FROM tags;");
 		res.json(result.rows);

--- a/backend/src/routes/articles_routes.js
+++ b/backend/src/routes/articles_routes.js
@@ -18,6 +18,19 @@ articleRouter.get("/", async (req, res, next) => {
 	}
 });
 
+
+//Get all tags
+articleRouter.get("/tags", async (req, res) => {
+	try {
+		const result = await pool.query("SELECT tag_name FROM tags;");
+		res.json(result.rows);
+	} catch (err) {
+		console.log(err);
+		res.status(500).send("An Internal Server Error Occurred");
+	}
+});
+
+
 // Get articles by article ID
 articleRouter.get("/:id", async (req, res, next) => {
 	const { id } = req.params;
@@ -144,17 +157,6 @@ articleRouter.get("/with-tag/:tagName", async (req, res) => {
 	} catch (err) {
 		console.log(err);
 		res.status(500).send("Internal Server Error");
-	}
-});
-
-//Get all tags
-articleRouter.get("/tags/getall", async (req, res) => {
-	try {
-		const result = await pool.query("SELECT tag_name FROM tags;");
-		res.json(result.rows);
-	} catch (err) {
-		console.log(err);
-		res.status(500).send("An Internal Server Error Occurred");
 	}
 });
 

--- a/frontend/src/components/ui/site-header/SiteHeader.jsx
+++ b/frontend/src/components/ui/site-header/SiteHeader.jsx
@@ -16,8 +16,8 @@ function SiteHeader() {
 	const navLinks = [];
 	if (isLoggedIn) {
 		navLinks.push(
-			{ label: "My articles", url: "/my-things/" },
-			{ label: "Add article", url: "/my-things/add/" },
+			{ label: "My articles", url: "/my/" },
+			{ label: "Add article", url: "/my/add/" },
 		);
 	} else {
 		navLinks.push(

--- a/frontend/src/components/ui/site-nav/SiteNav.jsx
+++ b/frontend/src/components/ui/site-nav/SiteNav.jsx
@@ -8,7 +8,7 @@ function SiteNav() {
 
 	const navLinks = [
 		{ label: "Home", url: "/" },
-		{ label: "Articles", url: "/things/" },
+		{ label: "Articles", url: "/articles/" },
 	];
 
 	if (isLoggedIn) {

--- a/frontend/src/components/ui/site-nav/SiteNav.jsx
+++ b/frontend/src/components/ui/site-nav/SiteNav.jsx
@@ -9,6 +9,7 @@ function SiteNav() {
 	const navLinks = [
 		{ label: "Home", url: "/" },
 		{ label: "Articles", url: "/articles/" },
+		{ label: "Tags", url: "/tags" },
 	];
 
 	if (isLoggedIn) {

--- a/frontend/src/components/views/add-thing/AddThing.jsx
+++ b/frontend/src/components/views/add-thing/AddThing.jsx
@@ -19,7 +19,7 @@ const AddThing = () => {
 		dispatch(
 			setBreadcrumb([
 				{ label: "Home", url: "/" },
-				{ label: "Add thing" },
+				{ label: "Add article" },
 			]),
 		);
 	}, [dispatch]);
@@ -31,7 +31,7 @@ const AddThing = () => {
 		setTag("");
 		setName("");
 		setDescription("");
-		navigate("/my-things/");
+		navigate("/my/");
 	};
 
 	return (

--- a/frontend/src/components/views/delete-thing/DeleteThing.jsx
+++ b/frontend/src/components/views/delete-thing/DeleteThing.jsx
@@ -20,7 +20,7 @@ const DeleteThing = () => {
 		dispatch(
 			setBreadcrumb([
 				{ label: "Home", url: "/" },
-				{ label: "My article", url: "/my-things/" },
+				{ label: "My article", url: "/my/" },
 				{ label: "Delete article" },
 			]),
 		);
@@ -35,8 +35,8 @@ const DeleteThing = () => {
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		await dispatch(deleteThing(thing.id));
-		dispatch(showToast(`Thing deleted`));
-		navigate("/my-things/");
+		dispatch(showToast(`Article deleted`));
+		navigate("/my/");
 	};
 
 	return (

--- a/frontend/src/components/views/edit-thing/EditThing.jsx
+++ b/frontend/src/components/views/edit-thing/EditThing.jsx
@@ -22,7 +22,7 @@ const EditThing = () => {
 		dispatch(
 			setBreadcrumb([
 				{ label: "Home", url: "/" },
-				{ label: "My articles", url: "/my-things/" },
+				{ label: "My articles", url: "/my/" },
 				{ label: "Edit article" },
 			]),
 		);
@@ -49,7 +49,7 @@ const EditThing = () => {
 			}),
 		);
 		dispatch(showToast(`${thing.title} updated!`));
-		navigate("/my-things/");
+		navigate("/my/");
 	};
 
 	return (

--- a/frontend/src/components/views/login/Login.jsx
+++ b/frontend/src/components/views/login/Login.jsx
@@ -25,7 +25,7 @@ const Login = () => {
 		e.preventDefault();
 		try {
 			await dispatch(login({ email, password })).unwrap();
-			navigate("/my-things/");
+			navigate("/my/");
 		} catch (error) {
 			console.error(error);
 		}

--- a/frontend/src/components/views/register/Register.jsx
+++ b/frontend/src/components/views/register/Register.jsx
@@ -27,7 +27,7 @@ const Register = () => {
 		try {
 			await register(name, email, password, bio);
 			await dispatch(login({ email, password })).unwrap();
-			navigate("/my-things/add/");
+			navigate("/my/add/");
 		} catch (error) {
 			console.error(error);
 		}

--- a/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
+++ b/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
@@ -19,9 +19,13 @@ const TagList = () => {
 
 	useEffect(() => {
 		dispatch(
-			setBreadcrumb([{ label: "Home", url: "/" }, { label: "Tags" }]),
+			setBreadcrumb([
+				{ label: "Home", url: "/" },
+				{ label: "Tags", url: "/tags" },
+				{ label: tagName },
+			]),
 		);
-	}, [dispatch]);
+	}, [dispatch, tagName]);
 
 	return (
 		<div className={styles.wrapper}>

--- a/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
+++ b/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { NavLink } from "react-router-dom";
+
+import { setBreadcrumb } from "../../../slices/breadcrumbSlice";
+import { fetchAllArticlesByTags } from "../../../slices/thingsSlice";
+
+import styles from "./TagArticlesList.module.css";
+
+const TagList = () => {
+	const dispatch = useDispatch();
+	const things = useSelector((state) => state.things.items);
+	const status = useSelector((state) => state.things.status);
+	const error = useSelector((state) => state.things.error);
+
+	useEffect(() => {
+		dispatch(fetchAllArticlesByTags());
+	}, [dispatch]);
+
+	useEffect(() => {
+		dispatch(
+			setBreadcrumb([{ label: "Home", url: "/" }, { label: "Tags" }]),
+		);
+	}, [dispatch]);
+
+	return (
+		<div className={styles.wrapper}>
+			{status === "loading" && <div>Loading...</div>}
+			{status === "failed" && <div>{error}</div>}
+			<ul className={styles.list}>
+				{things.map((thing) => (
+					<li className={styles.item} key={thing.id}>
+						<NavLink
+							className={styles.link}
+							to={`/tags/${thing.tag_name}/`}
+						>
+							{thing.tag_name}
+						</NavLink>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+};
+
+export default TagList;

--- a/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
+++ b/frontend/src/components/views/tag-articles-list/TagArticlesList.jsx
@@ -1,21 +1,21 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { NavLink } from "react-router-dom";
+import { NavLink, useParams } from "react-router-dom";
 
 import { setBreadcrumb } from "../../../slices/breadcrumbSlice";
 import { fetchAllArticlesByTags } from "../../../slices/thingsSlice";
-
 import styles from "./TagArticlesList.module.css";
 
 const TagList = () => {
+	const { tagName } = useParams();
 	const dispatch = useDispatch();
 	const things = useSelector((state) => state.things.items);
 	const status = useSelector((state) => state.things.status);
 	const error = useSelector((state) => state.things.error);
 
 	useEffect(() => {
-		dispatch(fetchAllArticlesByTags());
-	}, [dispatch]);
+		dispatch(fetchAllArticlesByTags(tagName));
+	}, [dispatch, tagName]);
 
 	useEffect(() => {
 		dispatch(
@@ -32,9 +32,9 @@ const TagList = () => {
 					<li className={styles.item} key={thing.id}>
 						<NavLink
 							className={styles.link}
-							to={`/tags/${thing.tag_name}/`}
+							to={`/articles/${thing.id}/`}
 						>
-							{thing.tag_name}
+							{thing.title}
 						</NavLink>
 					</li>
 				))}

--- a/frontend/src/components/views/tag-articles-list/TagArticlesList.module.css
+++ b/frontend/src/components/views/tag-articles-list/TagArticlesList.module.css
@@ -1,0 +1,35 @@
+.wrapper {
+	background: #efefef;
+	width: 100%;
+	padding: 1rem;
+}
+
+.list {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: flex-start;
+	margin: 0;
+	padding: 0;
+}
+
+.item {
+	list-style: none;
+	flex-basis: 50%;
+}
+
+@media (min-width: 600px) {
+	.item {
+		flex-basis: 33.33%;
+	}
+}
+
+.link {
+	display: block;
+	padding: 10px;
+	margin-right: 10px;
+	margin-bottom: 10px;
+	border: 1px solid #ccc;
+	border-radius: 10px;
+	text-align: center;
+}

--- a/frontend/src/components/views/tag-list/tag-list.jsx
+++ b/frontend/src/components/views/tag-list/tag-list.jsx
@@ -32,7 +32,7 @@ const TagList = () => {
 					<li className={styles.item} key={thing.id}>
 						<NavLink
 							className={styles.link}
-							to={`/tags/${thing.id}/`}
+							to={`/with-tag/${thing.tag_name}/`}
 						>
 							{thing.tag_name}
 						</NavLink>

--- a/frontend/src/components/views/tag-list/tag-list.jsx
+++ b/frontend/src/components/views/tag-list/tag-list.jsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { NavLink } from "react-router-dom";
+
+import { setBreadcrumb } from "../../../slices/breadcrumbSlice";
+import { fetchAllTags } from "../../../slices/thingsSlice";
+
+import styles from "./tag-list.module.css";
+
+const TagList = () => {
+	const dispatch = useDispatch();
+	const things = useSelector((state) => state.things.items);
+	const status = useSelector((state) => state.things.status);
+	const error = useSelector((state) => state.things.error);
+
+	useEffect(() => {
+		dispatch(fetchAllTags());
+	}, [dispatch]);
+
+	useEffect(() => {
+		dispatch(
+			setBreadcrumb([{ label: "Home", url: "/" }, { label: "Tags" }]),
+		);
+	}, [dispatch]);
+
+	return (
+		<div className={styles.wrapper}>
+			{status === "loading" && <div>Loading...</div>}
+			{status === "failed" && <div>{error}</div>}
+			<ul className={styles.list}>
+				{things.map((thing) => (
+					<li className={styles.item} key={thing.id}>
+						<NavLink
+							className={styles.link}
+							to={`/tags/${thing.id}/`}
+						>
+							{thing.tag_name}
+						</NavLink>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+};
+
+export default TagList;

--- a/frontend/src/components/views/tag-list/tag-list.module.css
+++ b/frontend/src/components/views/tag-list/tag-list.module.css
@@ -1,0 +1,35 @@
+.wrapper {
+	background: #efefef;
+	width: 100%;
+	padding: 1rem;
+}
+
+.list {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: flex-start;
+	margin: 0;
+	padding: 0;
+}
+
+.item {
+	list-style: none;
+	flex-basis: 50%;
+}
+
+@media (min-width: 600px) {
+	.item {
+		flex-basis: 33.33%;
+	}
+}
+
+.link {
+	display: block;
+	padding: 10px;
+	margin-right: 10px;
+	margin-bottom: 10px;
+	border: 1px solid #ccc;
+	border-radius: 10px;
+	text-align: center;
+}

--- a/frontend/src/components/views/thing-detail/ThingDetail.jsx
+++ b/frontend/src/components/views/thing-detail/ThingDetail.jsx
@@ -51,7 +51,20 @@ const ThingDetail = () => {
 			</p>
 			<p>
 				<strong>Tags: </strong>
-				<em> {thing.tags.join(", ")}</em>
+				<em>
+					{thing.tags.map((tag) => {
+						return (
+							<NavLink
+								style={{ marginLeft: 14 }}
+								key={tag}
+								className={styles.link}
+								to={`/with-tag/${tag}/`}
+							>
+								{tag}
+							</NavLink>
+						);
+					})}
+				</em>
 			</p>
 
 			{isLoggedIn && (

--- a/frontend/src/components/views/thing-detail/ThingDetail.jsx
+++ b/frontend/src/components/views/thing-detail/ThingDetail.jsx
@@ -23,8 +23,8 @@ const ThingDetail = () => {
 		dispatch(
 			setBreadcrumb([
 				{ label: "Home", url: "/" },
-				{ label: "Articles", url: "/things/" },
-				{ label: thing?.name || "Thing" },
+				{ label: "Articles", url: "/articles/" },
+				{ label: thing?.name || "Article" },
 			]),
 		);
 	}, [dispatch, thing]);
@@ -38,7 +38,7 @@ const ThingDetail = () => {
 	}
 
 	if (!thing) {
-		return <div>Thing not found</div>;
+		return <div>Article not found</div>;
 	}
 
 	return (

--- a/frontend/src/components/views/things-list/ThingsList.jsx
+++ b/frontend/src/components/views/things-list/ThingsList.jsx
@@ -32,7 +32,7 @@ const ThingsList = () => {
 					<li className={styles.item} key={thing.id}>
 						<NavLink
 							className={styles.link}
-							to={`/things/${thing.id}/`}
+							to={`/articles/${thing.id}/`}
 						>
 							{thing.title}
 						</NavLink>

--- a/frontend/src/components/views/user-detail/UserDetail.jsx
+++ b/frontend/src/components/views/user-detail/UserDetail.jsx
@@ -57,7 +57,7 @@ const UserDetail = () => {
 					<li key={thing.id}>
 						<NavLink
 							className={styles.link}
-							to={`/things/${thing.id}/`}
+							to={`/articles/${thing.id}/`}
 						>
 							{thing.title}
 						</NavLink>

--- a/frontend/src/components/views/users-list/UsersList.jsx
+++ b/frontend/src/components/views/users-list/UsersList.jsx
@@ -23,7 +23,6 @@ const UsersList = () => {
 		);
 	}, [dispatch]);
 
-	console.log(users)
 
 	return (
 		<div className={styles.wrapper}>

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -30,27 +30,27 @@ const routes = [
 				element: <Register />,
 			},
 			{
-				path: "things/",
+				path: "articles/",
 				element: <ThingsList />,
 			},
 			{
-				path: "things/:id/",
+				path: "articles/:id/",
 				element: <ThingDetail />,
 			},
 			{
-				path: "my-things/",
+				path: "my/",
 				element: <ProtectedRoute element={<MyThings />} />,
 			},
 			{
-				path: "my-things/add/",
+				path: "my/add/",
 				element: <ProtectedRoute element={<AddThing />} />,
 			},
 			{
-				path: "my-things/:id/edit/",
+				path: "my/:id/edit/",
 				element: <ProtectedRoute element={<EditThing />} />,
 			},
 			{
-				path: "my-things/:id/delete/",
+				path: "my/:id/delete/",
 				element: <ProtectedRoute element={<DeleteThing />} />,
 			},
 			{

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -7,10 +7,12 @@ import Home from "./components/views/home/Home";
 import Login from "./components/views/login/Login";
 import MyThings from "./components/views/my-things/MyThings";
 import Register from "./components/views/register/Register";
+import TagList from "./components/views/tag-list/tag-list";
 import ThingDetail from "./components/views/thing-detail/ThingDetail";
 import ThingsList from "./components/views/things-list/ThingsList";
 import UserDetail from "./components/views/user-detail/UserDetail";
 import UsersList from "./components/views/users-list/UsersList";
+import TagArticlesList from "./components/views/tag-articles-list/TagArticlesList";
 
 const routes = [
 	{
@@ -32,6 +34,14 @@ const routes = [
 			{
 				path: "articles/",
 				element: <ThingsList />,
+			},
+			{
+				path: "tags/",
+				element: <TagList />,
+			},
+			{
+				path:"with-tag/:tagName",
+				element: <TagArticlesList/>
 			},
 			{
 				path: "articles/:id/",

--- a/frontend/src/slices/thingsSlice.js
+++ b/frontend/src/slices/thingsSlice.js
@@ -65,14 +65,6 @@ export const deleteThing = createAsyncThunk(
 	},
 );
 
-// // TODO: ADD tags
-// export const addTag = createAsyncThunk(
-// 	"things/addTag",
-// 	async (id) => {
-// 		await makeApiRequest(`with-tags/${id}`, { method: "POST" });
-// 		return id;
-// 	},
-// );
 
 // TODO: GET articles by TAGS
 // TODO: take tag name rather than id

--- a/frontend/src/slices/thingsSlice.js
+++ b/frontend/src/slices/thingsSlice.js
@@ -79,11 +79,10 @@ export const deleteThing = createAsyncThunk(
 // "/with-tag/:id"
 export const fetchAllArticlesByTags = createAsyncThunk(
 	"things/allArticlesByTags",
-	async (tagName) => {
-		const response = await makeApiRequest(`with-tag/${tagName}`, {
+	async (tag_name) => {
+		return await makeApiRequest(`articles/with-tag/${tag_name}`, {
 			method: "GET",
 		});
-		return response;
 	},
 );
 

--- a/frontend/src/slices/thingsSlice.js
+++ b/frontend/src/slices/thingsSlice.js
@@ -94,7 +94,7 @@ export const fetchTagsForArticles = createAsyncThunk(
 // TODO: GET all tags
 // '/tags'
 export const fetchAllTags = createAsyncThunk("things/allArticles", async () => {
-	const response = await makeApiRequest(`articles/tags/getall`, {
+	const response = await makeApiRequest(`articles/tags`, {
 		method: "GET",
 	});
 	return response;

--- a/frontend/src/slices/thingsSlice.js
+++ b/frontend/src/slices/thingsSlice.js
@@ -79,8 +79,8 @@ export const deleteThing = createAsyncThunk(
 // "/with-tag/:id"
 export const fetchAllArticlesByTags = createAsyncThunk(
 	"things/allArticlesByTags",
-	async (id) => {
-		const response = await makeApiRequest(`with-tag/${id}`, {
+	async (tagName) => {
+		const response = await makeApiRequest(`with-tag/${tagName}`, {
 			method: "GET",
 		});
 		return response;
@@ -103,7 +103,9 @@ export const fetchTagsForArticles = createAsyncThunk(
 // TODO: GET all tags
 // '/tags'
 export const fetchAllTags = createAsyncThunk("things/allArticles", async () => {
-	const response = await makeApiRequest(`tags`, { method: "GET" });
+	const response = await makeApiRequest(`articles/tags/getall`, {
+		method: "GET",
+	});
 	return response;
 });
 
@@ -179,6 +181,28 @@ const thingsSlice = createSlice({
 				state.items = state.items.filter(
 					(item) => item.id !== action.payload,
 				);
+			})
+			.addCase(fetchAllTags.pending, (state) => {
+				state.status = "loading";
+			})
+			.addCase(fetchAllTags.fulfilled, (state, action) => {
+				state.status = "succeeded";
+				state.items = action.payload;
+			})
+			.addCase(fetchAllTags.rejected, (state, action) => {
+				state.status = "failed";
+				state.error = action.error.message;
+			})
+			.addCase(fetchAllArticlesByTags.pending, (state) => {
+				state.status = "loading";
+			})
+			.addCase(fetchAllArticlesByTags.fulfilled, (state, action) => {
+				state.status = "succeeded";
+				state.items = action.payload;
+			})
+			.addCase(fetchAllArticlesByTags.rejected, (state, action) => {
+				state.status = "failed";
+				state.error = action.error.message;
 			});
 	},
 });


### PR DESCRIPTION
## New Nav Bar Tab added for tags: 
![image](https://github.com/technative-academy/HoaxHaven/assets/119541585/844dcd41-5fae-42ef-98e3-ee936c669191)

 - Some backend api routing was changed as was getting confused and was trying to fetch and article with articleId = tagName. Now fetch all tag endpoint:  /tags ==> /tags/getall
 - Updated frontend reducers and thunkAPI's to extract backend data. 
 - Created 2 new JSX components and updated react-router to render these. These are lists of tag links which on click navigate you to a similar list of articles with related tag name.  Also breadcrumbs on second to top bar work as expected. 
 
![image](https://github.com/technative-academy/HoaxHaven/assets/119541585/d87be6da-8739-4252-bfaa-63f55873ee63)

## Routing

- Updated routing throughout frontend so that URL bar doesn't show "my-things" and "things" and also toast so pop-ups now don't show "thing added". 
- "my-things" ==> "my"
- "things" ==> "articles"
