### PR TITLE
Article view improvements

### DIFF
--- a/frontend/src/components/views/thing-detail/ThingDetail.jsx
+++ b/frontend/src/components/views/thing-detail/ThingDetail.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { NavLink, useParams } from "react-router-dom";
 
@@ -18,6 +18,11 @@ const ThingDetail = () => {
 	useEffect(() => {
 		dispatch(fetchThing(id));
 	}, [dispatch, id]);
+
+	const descriptionLines = useMemo(
+		() => thing?.description.split(/\r?\n+/),
+		[thing?.description],
+	);
 
 	useEffect(() => {
 		dispatch(
@@ -46,9 +51,19 @@ const ThingDetail = () => {
 			<p>
 				<strong>Name:</strong> <em>{thing.title}</em>
 			</p>
-			<p>
-				<strong>Description:</strong> <em>{thing.description}</em>
-			</p>
+			{isLoggedIn && (
+				<p>
+					<strong>Owner:</strong>
+					<em>
+						<NavLink
+							className={styles.link}
+							to={`/users/${thing.username}/`}
+						>
+							{thing.username}
+						</NavLink>
+					</em>
+				</p>
+			)}
 			<p>
 				<strong>Tags: </strong>
 				<em>
@@ -66,20 +81,13 @@ const ThingDetail = () => {
 					})}
 				</em>
 			</p>
+			<hr></hr>
 
-			{isLoggedIn && (
-				<p>
-					<strong>Owner:</strong>
-					<em>
-						<NavLink
-							className={styles.link}
-							to={`/users/${thing.username}/`}
-						>
-							{thing.username}
-						</NavLink>
-					</em>
-				</p>
-			)}
+			<div>
+				{descriptionLines.map((line) => (
+					<p>{line}</p>
+				))}
+			</div>
 		</div>
 	);
 };

--- a/frontend/src/components/views/thing-detail/thing-detail.module.css
+++ b/frontend/src/components/views/thing-detail/thing-detail.module.css
@@ -1,5 +1,6 @@
 .wrapper {
 	background: #efefef;
 	width: 100%;
+	height: fit-content;
 	padding: 1rem;
 }


### PR DESCRIPTION
 - New lines create separate paragraphs
 - Remove description label
 - Reorder article sections

## Before
![image](https://github.com/technative-academy/HoaxHaven/assets/16543008/d3c026c2-fd6e-4632-a473-a68f234d3299)

## After
![image](https://github.com/technative-academy/HoaxHaven/assets/16543008/f60e9265-0a25-4495-8455-80dbed472d43)

## Notes
 - Only splits on Unix line endings, but seemed to work when I copied something from Google Docs on Windows